### PR TITLE
allow multiple response lines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcumgr-client"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/test_serial_port.rs
+++ b/src/test_serial_port.rs
@@ -77,15 +77,16 @@ impl Write for TestSerialPort {
 
         match request_header.id {
             id if id == NmpIdImage::State as u8 => {
-                let empty_cbor_body =
-                    serde_cbor::to_vec(&std::collections::BTreeMap::<String, String>::new())
-                        .unwrap();
+                let mut map = std::collections::BTreeMap::<String, String>::new();
+                let test_string = "x".repeat(1024);
+                map.insert("test".to_string(), test_string);
+                let body = serde_cbor::to_vec(&map).unwrap();
                 let (encoded_response, _) = encode_request(
-                    100000,
+                    100,
                     NmpOp::ReadRsp,
                     NmpGroup::Image,
                     NmpIdImage::State,
-                    &empty_cbor_body,
+                    &body,
                     request_header.seq,
                 )
                 .unwrap();


### PR DESCRIPTION
This fixes https://github.com/vouch-opensource/mcumgr-client/issues/9 and https://github.com/vouch-opensource/mcumgr-client/issues/2 . It also adds a new test case for the "test" serial port device. Without this change, the command `mcumgr-client -v -d test list` fails with the "wrong chunk length" error, and with the changed in transfer.rs it succeeds.