### PR TITLE
GitHub/workflows/release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,20 +19,22 @@ jobs:
         include:
           - target: x86_64-pc-windows-gnu
             archive: zip
+            archive_name: mcumgr-client-windows-x86.zip
           - target: x86_64-unknown-linux-musl
-            archive: tar.gz tar.xz tar.zst
+            archive: zip
+            archive_name: mcumgr-client-linux-x86
           - target: x86_64-apple-darwin
             archive: zip
+            archive_name: mcumgr-client-macos-x86
 
     steps:
     - uses: actions/checkout@v4
-    # - name: Install Linux dependencies
-    #   if: matrix.os == 'ubuntu-latest'
-    #   run: sudo apt install libudev-dev
     - name: Build & Release
       uses: rust-build/rust-build.action@v1.4.4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         RUSTTARGET: ${{ matrix.target }}
+        ARCHIVE_TYPES: ${{ matrix.archive }}
+        ARCHIVE_NAME: ${{ matrix.archive_name }}
         EXTRA_FILES: "README.md LICENSE"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Build
       run: cargo build --release --target ${{ matrix.target }}
 
-    - name: Make zips
+    - name: Make zip
       run: |
         mkdir ${{ matrix.archive_name }}
         cp README.md ${{ matrix.archive_name }}
@@ -98,7 +98,7 @@ jobs:
           zip -r mcumgr-client-macos-universal.zip mcumgr-client-macos-universal
 
       - name: Make SHA256 checksum
-        run: sha256sum mcumgr-client-macos-universal.zip > mcumgr-client-macos-universal.zip.sha256sum
+        run: shasum -a 256 mcumgr-client-macos-universal.zip > mcumgr-client-macos-universal.zip.sha256sum
 
       - name: Upload universal to Release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install dependencies
+      run: sudo apt install mingw-w64
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
@@ -40,7 +43,7 @@ jobs:
         cp README.md ${{ matrix.archive_name }}
         cp LICENSE ${{ matrix.archive_name }}
         cp target/${{ matrix.target }}/release/mcumgr-client ${{ matrix.archive_name }}
-        zip ${{ matrix.archive_name }}.zip ${{ matrix.archive_name }}
+        zip -r ${{ matrix.archive_name }}.zip ${{ matrix.archive_name }}
 
     - name: Upload zips to Release
       uses: svenstaro/upload-release-action@v2
@@ -81,7 +84,7 @@ jobs:
           cp README.md mcumgr-client-macos-universal
           cp LICENSE mcumgr-client-macos-universal
           cp target/aarch64-apple-darwin/release/mcumgr-client mcumgr-client-macos-universal
-          zip mcumgr-client-macos-universal.zip mcumgr-client-macos-universal
+          zip -r mcumgr-client-macos-universal.zip mcumgr-client-macos-universal
 
       - name: Upload universal to Release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
         include:
           - target: x86_64-pc-windows-gnu
             archive_name: mcumgr-client-windows-x86
+            file_extension: .exe
           - target: x86_64-unknown-linux-musl
             archive_name: mcumgr-client-linux-x86
 
@@ -42,15 +43,25 @@ jobs:
         mkdir ${{ matrix.archive_name }}
         cp README.md ${{ matrix.archive_name }}
         cp LICENSE ${{ matrix.archive_name }}
-        cp target/${{ matrix.target }}/release/mcumgr-client ${{ matrix.archive_name }}
+        cp target/${{ matrix.target }}/release/mcumgr-client${{ matrix.file_extension }} ${{ matrix.archive_name }}
         zip -r ${{ matrix.archive_name }}.zip ${{ matrix.archive_name }}
 
-    - name: Upload zips to Release
+    - name: Make SHA256 checksum
+      run: sha256sum ${{ matrix.archive_name }}.zip > ${{ matrix.archive_name }}.zip.sha256sum
+
+    - name: Upload zip to Release
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: ${{ matrix.archive_name }}.zip
-        tag: ${{ github.ref }}    
+        tag: ${{ github.ref }}
+
+    - name: Upload SHA256 to Release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ matrix.archive_name }}.zip.sha256sum
+        tag: ${{ github.ref }}  
 
   release-macos-universal:
     name: macos-universal
@@ -86,9 +97,19 @@ jobs:
           cp target/aarch64-apple-darwin/release/mcumgr-client mcumgr-client-macos-universal
           zip -r mcumgr-client-macos-universal.zip mcumgr-client-macos-universal
 
+      - name: Make SHA256 checksum
+        run: sha256sum mcumgr-client-macos-universal.zip > mcumgr-client-macos-universal.zip.sha256sum
+
       - name: Upload universal to Release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: mcumgr-client-macos-universal.zip
           tag: ${{ github.ref }}
+
+      - name: Upload SHA256 to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: mcumgr-client-macos-universal.zip.sha256sum
+          tag: ${{ github.ref }}  

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
           file: mcumgr-client-macos-aarch64.zip
           tag: ${{ github.ref }}
 
-      - run: mkdir target/universal/release
+      - run: mkdir -p target/universal/release
       - name: Combine Binaries into Universal Binary
         run: >
           lipo -create -output 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,6 +72,7 @@ jobs:
           tag: ${{ github.ref }}
 
       - name: Combine Binaries into Universal Binary
+        run: mkdir target/universal/release
         run: >
           lipo -create -output 
           "target/universal/release/mcumgr-client"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  release:
+  release-x86:
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
     strategy:
@@ -38,3 +38,43 @@ jobs:
         ARCHIVE_TYPES: ${{ matrix.archive }}
         ARCHIVE_NAME: ${{ matrix.archive_name }}
         EXTRA_FILES: "README.md LICENSE"
+
+  release-macos-universal:
+    name: macos-universal
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-darwin
+
+      - name: Build aarch64
+        run: cargo build --release --target aarch64-apple-darwin
+
+      - name: Build x86
+        run: cargo build --release --target x86_64-apple-darwin
+
+      - name: Make aarch64 zip
+        run: |
+          mkdir mcumgr-client-macos-aarch64
+          cp target/aarch64-apple-darwin/release/mcumgr-client mcumgr-client-macos-aarch64/mcumgr-client
+          cp LICENSE mcumgr-client-macos-aarch64/LICENSE
+          cp README.md mcumgr-client-macos-aarch64/README.md
+          zip mcumgr-client-macos-aarch64
+
+      - name: Upload aarch64 to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: mcumgr-client-macos-aarch64
+          tag: ${{ github.ref }}
+      
+      - name: Combine Binaries into Universal Binary
+        run: >
+          lipo -create -output 
+          "target/universal/release/mcumgr-client"
+          "target/x86_64-apple-darwin/release/mcumgr-client"
+          "target/aarch64-apple-darwin/release/mcumgr-client"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
+        targets: x86_64-pc-windows-gnu, x86_64-unknown-linux-musl
 
     - name: Build
       run: cargo build --release --target ${{ matrix.target }}
@@ -58,7 +59,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          target: aarch64-apple-darwin
+          targets: aarch64-apple-darwin, x86_64-apple-darwin
 
       - name: Build aarch64
         run: cargo build --release --target aarch64-apple-darwin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: Release
+permissions:
+  contents: write
+
+on:
+  release:
+    types: [published]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-gnu
+            archive: zip
+          - target: x86_64-unknown-linux-musl
+            archive: tar.gz tar.xz tar.zst
+          - target: x86_64-apple-darwin
+            archive: zip
+
+    steps:
+    - uses: actions/checkout@v4
+    # - name: Install Linux dependencies
+    #   if: matrix.os == 'ubuntu-latest'
+    #   run: sudo apt install libudev-dev
+    - name: Build & Release
+      uses: rust-build/rust-build.action@v1.4.4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        RUSTTARGET: ${{ matrix.target }}
+        EXTRA_FILES: "README.md LICENSE"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         include:
           - target: x86_64-pc-windows-gnu
             archive: zip
-            archive_name: mcumgr-client-windows-x86.zip
+            archive_name: mcumgr-client-windows-x86
           - target: x86_64-unknown-linux-musl
             archive: zip
             archive_name: mcumgr-client-linux-x86

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,12 +68,26 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: mcumgr-client-macos-aarch64
+          file: mcumgr-client-macos-aarch64.zip
           tag: ${{ github.ref }}
-      
+
       - name: Combine Binaries into Universal Binary
         run: >
           lipo -create -output 
           "target/universal/release/mcumgr-client"
           "target/x86_64-apple-darwin/release/mcumgr-client"
           "target/aarch64-apple-darwin/release/mcumgr-client"
+
+      - name: Make universal zip
+        run: >
+          zip mcumgr-client-macos-universal.zip
+          target/universal/release/mcumgr-client
+          LICENSE
+          README.md
+
+      - name: Upload aarch64 to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: mcumgr-client-macos-universal.zip
+          tag: ${{ github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,12 +58,11 @@ jobs:
         run: cargo build --release --target x86_64-apple-darwin
 
       - name: Make aarch64 zip
-        run: |
-          mkdir mcumgr-client-macos-aarch64
-          cp target/aarch64-apple-darwin/release/mcumgr-client mcumgr-client-macos-aarch64/mcumgr-client
-          cp LICENSE mcumgr-client-macos-aarch64/LICENSE
-          cp README.md mcumgr-client-macos-aarch64/README.md
-          zip mcumgr-client-macos-aarch64
+        run: >
+          zip mcumgr-client-macos-aarch64.zip
+          target/aarch64-apple-darwin/release/mcumgr-client
+          LICENSE
+          README.md
 
       - name: Upload aarch64 to Release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,7 +86,7 @@ jobs:
           LICENSE
           README.md
 
-      - name: Upload aarch64 to Release
+      - name: Upload universal to Release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,26 +18,35 @@ jobs:
       matrix:
         include:
           - target: x86_64-pc-windows-gnu
-            archive: zip
             archive_name: mcumgr-client-windows-x86
           - target: x86_64-unknown-linux-musl
-            archive: zip
             archive_name: mcumgr-client-linux-x86
-          - target: x86_64-apple-darwin
-            archive: zip
-            archive_name: mcumgr-client-macos-x86
 
     steps:
     - uses: actions/checkout@v4
-    - name: Build & Release
-      uses: rust-build/rust-build.action@v1.4.4
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
       with:
-        RUSTTARGET: ${{ matrix.target }}
-        ARCHIVE_TYPES: ${{ matrix.archive }}
-        ARCHIVE_NAME: ${{ matrix.archive_name }}
-        EXTRA_FILES: "README.md LICENSE"
+        toolchain: stable
+
+    - name: Build
+      run: cargo build --release --target ${{ matrix.target }}
+
+    - name: Make zips
+      run: |
+        mkdir ${{ matrix.archive_name }}
+        cp README.md ${{ matrix.archive_name }}
+        cp LICENSE ${{ matrix.archive_name }}
+        cp target/${{ matrix.target }}/release/mcumgr-client ${{ matrix.archive_name }}
+        zip ${{ matrix.archive_name }}.zip ${{ matrix.archive_name }}
+
+    - name: Upload zips to Release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ matrix.archive_name }}.zip
+        tag: ${{ github.ref }}    
 
   release-macos-universal:
     name: macos-universal
@@ -46,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           target: aarch64-apple-darwin
@@ -57,20 +66,6 @@ jobs:
       - name: Build x86
         run: cargo build --release --target x86_64-apple-darwin
 
-      - name: Make aarch64 zip
-        run: >
-          zip mcumgr-client-macos-aarch64.zip
-          target/aarch64-apple-darwin/release/mcumgr-client
-          LICENSE
-          README.md
-
-      - name: Upload aarch64 to Release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: mcumgr-client-macos-aarch64.zip
-          tag: ${{ github.ref }}
-
       - run: mkdir -p target/universal/release
       - name: Combine Binaries into Universal Binary
         run: >
@@ -80,11 +75,12 @@ jobs:
           "target/aarch64-apple-darwin/release/mcumgr-client"
 
       - name: Make universal zip
-        run: >
-          zip mcumgr-client-macos-universal.zip
-          target/universal/release/mcumgr-client
-          LICENSE
-          README.md
+        run: |
+          mkdir mcumgr-client-macos-universal
+          cp README.md mcumgr-client-macos-universal
+          cp LICENSE mcumgr-client-macos-universal
+          cp target/aarch64-apple-darwin/release/mcumgr-client mcumgr-client-macos-universal
+          zip mcumgr-client-macos-universal.zip mcumgr-client-macos-universal
 
       - name: Upload universal to Release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,8 +71,8 @@ jobs:
           file: mcumgr-client-macos-aarch64.zip
           tag: ${{ github.ref }}
 
+      - run: mkdir target/universal/release
       - name: Combine Binaries into Universal Binary
-        run: mkdir target/universal/release
         run: >
           lipo -create -output 
           "target/universal/release/mcumgr-client"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,19 @@
 
 This is a Rust program to run mcumgr commands, used for example for Zephyr, for uploading firmware updates from a PC to an embedded device. It is an alternative to [the mcumgr Go program](https://github.com/apache/mynewt-mcumgr-cli).
 
-## Prerequisites
+## Download
+
+Released builds for x86-64 Windows, Linux, and MacOS are [here](https://github.com/vouch-opensource/mcumgr-client/releases).
+
+Example download:
+```
+wget https://github.com/vouch-opensource/mcumgr-client/releases/latest/download/mcumgr-client-linux-x86.zip
+wget -O - https://github.com/vouch-opensource/mcumgr-client/releases/latest/download/mcumgr-client-linux-x86.zip.sha256sum | sha256sum --check
+unzip mcumgr-client-linux-x86.zip -d mcumgr-client
+```
+
+## Build Dependencies
+
 Install Rust:
 
 Recommended is with [rustup](https://www.rust-lang.org/tools/install), because then it is easy to keep it up to date.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Example download:
 ```
 wget https://github.com/vouch-opensource/mcumgr-client/releases/latest/download/mcumgr-client-linux-x86.zip
 wget -O - https://github.com/vouch-opensource/mcumgr-client/releases/latest/download/mcumgr-client-linux-x86.zip.sha256sum | sha256sum --check
-unzip mcumgr-client-linux-x86.zip -d mcumgr-client
+unzip mcumgr-client-linux-x86.zip
 ```
 
 ## Build Dependencies


### PR DESCRIPTION
This PR adds a GitHub workflow utilizing this action: https://github.com/marketplace/actions/rust-release-binary

After this is merged main should be git tagged.  The tag should match the cargo version - I wonder if there is a way to sync git tags to cargo version?

With the tag in place, creating a Release on GitHub should trigger this action which will:

* build x86 binaries for Windows, Mac and Linux
* copy the LICENSE and README.md to a folder named `mcumgr-client-<target>-x86` then zip it
* get a SHA256 checksum of each zip
* upload the zips and checksums to the release page

The workflow took between 1-2 minutes for me.  

See an example of what the release page will look like here: https://github.com/JPHutchins/mcumgr-client/releases/tag/0

And logs from the run: https://github.com/JPHutchins/mcumgr-client/actions/runs/6821898796

Note that I have only minimally tested (AKA executed) the linux and windows binaries.

TODO: get "Apple Silicon" builds working.  I was not able to cross-compile from x86 Linux.  Apparently, if GitHub x86 mac runners are using MacOS >= 11, I can get this working.  More information: https://github.com/rust-lang/rust-analyzer/issues/6732