### PR TITLE
Fix image upload hanging when MTU is increased

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,11 +19,11 @@ pub struct Cli {
     pub verbose: bool,
 
     /// initial timeout in seconds
-    #[arg(short = 'i', long = "initial_timeout", default_value_t = 60)]
+    #[arg(short = 't', long = "initial_timeout", default_value_t = 60)]
     pub initial_timeout_s: u32,
 
     /// subsequent timeout in msec
-    #[arg(short = 't', long = "subsequent_timeout", default_value_t = 200)]
+    #[arg(short = 'u', long = "subsequent_timeout", default_value_t = 200)]
     pub subsequent_timeout_ms: u32,
 
     // number of retry per packet

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,9 +18,17 @@ pub struct Cli {
     #[arg(short, long)]
     pub verbose: bool,
 
-    /// maximum timeout in seconds
-    #[arg(short, long, default_value_t = 60)]
-    pub timeout: u32,
+    /// initial timeout in seconds
+    #[arg(short = 'i', long = "initial_timeout", default_value_t = 60)]
+    pub initial_timeout_s: u32,
+
+    /// subsequent timeout in msec
+    #[arg(short = 't', long = "subsequent_timeout", default_value_t = 200)]
+    pub subsequent_timeout_ms: u32,
+
+    // number of retry per packet
+    #[arg(long, default_value_t = 4)]
+    pub nb_retry: u32,
 
     /// maximum length per line
     #[arg(short, long, default_value_t = 128)]

--- a/src/default.rs
+++ b/src/default.rs
@@ -15,10 +15,10 @@ use crate::transfer::transceive;
 
 pub fn reset(cli: &Cli) -> Result<(), Error> {
     info!("send reset request");
-    
+
     // open serial port
     let mut port = open_port(cli)?;
-   
+
     // send request
     let body = Vec::new();
     let (data, request_header) = encode_request(
@@ -29,7 +29,7 @@ pub fn reset(cli: &Cli) -> Result<(), Error> {
         &body,
         next_seq_id(),
     )?;
-    let (response_header, response_body) = transceive(&mut *port, data)?;
+    let (response_header, response_body) = transceive(&mut *port, &data)?;
     
     // verify sequence id
     if response_header.seq != request_header.seq {

--- a/src/image.rs
+++ b/src/image.rs
@@ -215,7 +215,7 @@ pub fn upload(cli: &Cli, filename: &PathBuf) -> Result<(), Error> {
             break;
         }
     
-        // The first packet was sent and the device has cleared his internal flash
+        // The first packet was sent and the device has cleared its internal flash
         // We can now lower the timeout in case of failed transmission
         port.set_timeout(Duration::from_millis(cli.subsequent_timeout_ms as u64))?;
     }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -38,7 +38,7 @@ pub fn open_port(cli: &Cli) -> Result<Box<dyn SerialPort>, Error> {
         Ok(Box::new(TestSerialPort::new()))
     } else {
         serialport::new(&cli.device, cli.baudrate)
-            .timeout(Duration::from_secs(cli.timeout as u64))
+            .timeout(Duration::from_secs(cli.initial_timeout_s as u64))
             .open()
             .with_context(|| format!("failed to open serial port {}", &cli.device))
     }
@@ -110,7 +110,7 @@ pub fn encode_request(
 
 pub fn transceive(
     port: &mut dyn SerialPort,
-    data: Vec<u8>,
+    data: &Vec<u8>,
 ) -> Result<(NmpHdr, serde_cbor::Value), Error> {
     // empty input buffer
     let to_read = port.bytes_to_read()?;
@@ -119,14 +119,14 @@ pub fn transceive(
     }
 
     // write request
-    port.write_all(&data)?;
+    port.write_all(data)?;
 
     // read result
     let mut bytes_read = 0;
     let mut expected_len = 0;
     let mut result: Vec<u8> = Vec::new();
     loop {
-        // first wait for the chunk start marker
+        debug!("waiting for the chunk start marker");
         if bytes_read == 0 {
             expect_byte(&mut *port, 6)?;
             expect_byte(&mut *port, 9)?;

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -126,7 +126,7 @@ pub fn transceive(
     let mut expected_len = 0;
     let mut result: Vec<u8> = Vec::new();
     loop {
-        debug!("waiting for the chunk start marker");
+        // first wait for the chunk start marker
         if bytes_read == 0 {
             expect_byte(&mut *port, 6)?;
             expect_byte(&mut *port, 9)?;


### PR DESCRIPTION
# Description

When working with Zephyr OS i came across a similar issue as discussed in #8.

I did some investigation and found that the client was waiting indefinitly for a response from the mcu, on the chunk start markers.

I'm assuming the mcu did not receive a valid frame and dropped it without sending an answer.

# Changes

Lowered the read timeout and added a retry to send the unanswerd data chuncks again.

I was able to upload an image through uart at 921600b | MTU 1024 | line len 8192.