### PR TITLE
Add repository and license to manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "mcumgr-client"
 version = "0.0.4"
 edition = "2021"
+repository = "https://github.com/vouch-opensource/mcumgr-client/"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Added repository and license fields to the cargo manifest. So that [cargo-bitbake](https://github.com/meta-rust/cargo-bitbake) can be run on the project. 
