### PR TITLE
Fix wrong chunk length

### DIFF
--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -157,7 +157,7 @@ pub fn transceive(
         }
 
         // stop when done
-        if decoded.len() >= expected_len {
+        if (decoded.len() - 2) >= expected_len {
             break;
         }
     }


### PR DESCRIPTION
In some rare cases there is a small subsequent frame which is not read and transceive aborts with `wrong chunk length`

I have mcuboot (zephyr) with the option `CONFIG_SINGLE_APPLICATION_SLOT=y` and use the serial recovery mode. There is an image on the controller with the version `3.7.99.782043700`. I wanted to get the list of images and it failed with `wrong chunk length`

To be honest I don't completely understand the code. I just saw that there is only the first frame read and the second not. Here https://github.com/vouch-opensource/mcumgr-client/blob/3d910e0b148a8e8c312598065406263a8dd21530/src/transfer.rs#L171 the 2 bytes to encode the length are subtracted and here https://github.com/vouch-opensource/mcumgr-client/blob/3d910e0b148a8e8c312598065406263a8dd21530/src/transfer.rs#L160 not. 
I subtracted this 2 bytes too and it works now. I tested list, upload and reset with the fix and had no issues.