### PR TITLE
Implement reset and test commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ byteorder = "1.4"
 clap = { version = "4", features = ["derive"] }
 crc16 = "0.4"
 hex = "0.4"
+hex-buffer-serde = "0.4.0"
 humantime = "2.1.0"
 indicatif = "0.17"
 lazy_static = "1.4"

--- a/src/image.rs
+++ b/src/image.rs
@@ -18,7 +18,119 @@ use crate::transfer::open_port;
 use crate::transfer::transceive;
 use crate::transfer::SerialSpecs;
 
-pub fn list(specs: &SerialSpecs) -> Result<serde_cbor::Value, Error> {
+fn get_rc(response_body: &serde_cbor::Value) -> Option<u32> {
+    let mut rc: Option<u32> = None;
+    if let serde_cbor::Value::Map(object) = response_body {
+        for (key, val) in object.iter() {
+            match key {
+                serde_cbor::Value::Text(rc_key) if rc_key == "rc" => {
+                    if let serde_cbor::Value::Integer(parsed_rc) = val {
+                        rc = Some(*parsed_rc as u32);
+                    }
+                }
+                _ => (),
+            }
+        }
+    }
+    rc
+}
+
+fn check_answer(request_header: &NmpHdr, response_header: &NmpHdr) -> bool
+{
+    // verify sequence id
+    if response_header.seq != request_header.seq {
+        log::debug!("wrong sequence number");
+        return false;
+    }
+
+    let expected_op_type = match request_header.op {
+        NmpOp::Read => NmpOp::ReadRsp,
+        NmpOp::Write => NmpOp::WriteRsp,
+        _ => panic!("Unexpected type")
+    }; 
+
+    // verify response
+    if response_header.op != expected_op_type || response_header.group != request_header.group {
+        log::debug!("wrong response types");
+        return false;
+    }
+
+    true
+} 
+
+pub fn erase(specs: &SerialSpecs, slot: Option<u32>) -> Result<(), Error> {
+    info!("erase request");
+
+    // open serial port
+    let mut port = open_port(specs)?;
+
+    let req = ImageEraseReq {
+        slot : slot
+    };
+    let body = serde_cbor::to_vec(&req)?;
+    // send request
+    let (data, request_header) = encode_request(
+        specs.linelength,
+        NmpOp::Write,
+        NmpGroup::Image,
+        NmpIdImage::Erase,
+        &body,
+        next_seq_id(),
+    )?;
+    let (response_header, response_body) = transceive(&mut *port, &data)?;
+
+    if !check_answer(&request_header, &response_header) {
+        bail!("wrong answer types")
+    }
+
+    if let Some(rc) = get_rc(&response_body) {
+        if rc != 0 {
+            bail!("Error from device: {}", rc);
+        }
+    }
+
+    log::debug!("{:?}", response_body);
+    Ok(())
+}
+
+pub fn test(specs: &SerialSpecs, hash: Vec<u8>, confirm: Option<bool>) -> Result<(), Error> {
+    info!("set image pending request");
+
+    // open serial port
+    let mut port = open_port(specs)?;
+
+    let req = ImageStateReq {
+        hash: hash,
+        confirm : confirm
+    };
+    let body = serde_cbor::to_vec(&req)?;
+    // send request
+    let (data, request_header) = encode_request(
+        specs.linelength,
+        NmpOp::Write,
+        NmpGroup::Image,
+        NmpIdImage::State,
+        &body,
+        next_seq_id(),
+    )?;
+    let (response_header, response_body) = transceive(&mut *port, &data)?;
+
+    if !check_answer(&request_header, &response_header) {
+        bail!("wrong answer types")
+    }
+
+    if let Some(rc) = get_rc(&response_body) {
+        if rc != 0 {
+            return Err(anyhow::format_err!("Error from device: {}", rc));
+        }
+    }
+
+    log::debug!("{:?}", response_body);
+    Ok(())
+}
+
+
+pub fn list(specs: &SerialSpecs) -> Result<Vec<ImageStateEntry>, Error> {
     info!("send image list request");
 
     // open serial port
@@ -37,17 +149,13 @@ pub fn list(specs: &SerialSpecs) -> Result<serde_cbor::Value, Error> {
     )?;
     let (response_header, response_body) = transceive(&mut *port, &data)?;
 
-    // verify sequence id
-    if response_header.seq != request_header.seq {
-        bail!("wrong sequence number");
+    if !check_answer(&request_header, &response_header) {
+        bail!("wrong answer types")
     }
 
-    // verify response
-    if response_header.op != NmpOp::ReadRsp || response_header.group != NmpGroup::Image {
-        bail!("wrong response types");
-    }
+    let ans: ImageStateRsp = serde_cbor::value::from_value(response_body)?;
 
-    Ok(response_body)
+    Ok(ans.images)
 }
 
 pub fn upload<F>(specs: &SerialSpecs, filename: &PathBuf, slot: u8, mut progress: Option<F>) -> Result<(), Error> where 
@@ -155,14 +263,8 @@ pub fn upload<F>(specs: &SerialSpecs, filename: &PathBuf, slot: u8, mut progress
                 Err(e) => return Err(e),
             };
 
-            // verify sequence id
-            if response_header.seq != request_header.seq {
-                bail!("wrong sequence number");
-            }
-
-            // verify response
-            if response_header.op != NmpOp::WriteRsp || response_header.group != NmpGroup::Image {
-                bail!("wrong response types");
+            if !check_answer(&request_header, &response_header) {
+                bail!("wrong answer types")
             }
 
             // verify result code and update offset

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,5 @@ mod transfer;
 mod test_serial_port;
 
 pub use crate::default::reset;
-pub use crate::image::{list, upload};
+pub use crate::image::{list, upload, test, erase};
 pub use crate::transfer::SerialSpecs;

--- a/src/nmp_hdr.rs
+++ b/src/nmp_hdr.rs
@@ -1,5 +1,6 @@
 // Copyright © 2023-2024 Vouch.io LLC
 
+use hex_buffer_serde::{Hex as _, HexForm};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use num;
 use num_derive::FromPrimitive;
@@ -203,8 +204,12 @@ pub enum SplitStatus {
     Matching = 2,
 }
 
-fn default_0() -> i32 {
+fn default_0() -> u32 {
     0
+}
+
+fn default_false() -> bool {
+    false
 }
 
 fn default_vec() -> Vec<u8> {
@@ -214,26 +219,37 @@ fn default_vec() -> Vec<u8> {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ImageStateEntry {
     #[serde(default = "default_0")]
-    pub image: i32,
-    pub slot: i32,
+    pub image: u32,
+    pub slot: u32,
     pub version: String,
-    #[serde(default = "default_vec")]
+    #[serde(default = "default_vec", with = "HexForm")]
     pub hash: Vec<u8>,
+    #[serde(default = "default_false")]
     pub bootable: bool,
+    #[serde(default = "default_false")]
     pub pending: bool,
+    #[serde(default = "default_false")]
     pub confirmed: bool,
+    #[serde(default = "default_false")]
     pub active: bool,
+    #[serde(default = "default_false")]
     pub permanent: bool,
 
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }
 
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ImageStateReq {
+    #[serde(with = "serde_bytes")]
+    pub hash: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confirm: Option<bool>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ImageStateRsp {
-    #[serde(rename = "hdr")]
-    pub nmp_base: NmpBase,
-    pub rc: i32,
     pub images: Vec<ImageStateEntry>,
     #[serde(rename = "splitStatus")]
     pub split_status: SplitStatus,
@@ -261,4 +277,10 @@ pub struct ImageUploadReq {
     pub data_sha: Option<Vec<u8>>,
     #[serde(rename = "upgrade", default, skip_serializing_if = "Option::is_none")]
     pub upgrade: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ImageEraseReq {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slot: Option<u32>,
 }


### PR DESCRIPTION
This pr implements 2 extra functions of the image group:
 - erase: erase the image in the current inactive slot or the specified one.
 - test: set the pending flag of the specified image. With the pending flag set, the image will be selected for upgrade on next reboot.

I also edited the list function to return a vector of ImageStateEntry instead of a generic serde_cbor::Value.
This allowed me to specify a specific deserializer for the hash field to display it as a HEX string, a more human readable format.
I needed it to be a hex string as I was expecting a hex string hash in argument of the test function.