### PR TITLE
Fix nb_retry comment

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ struct Cli {
     #[arg(short = 'u', long = "subsequent_timeout", default_value_t = 200)]
     subsequent_timeout_ms: u32,
 
-    // number of retry per packet
+    // number of retries per packet
     #[arg(long, default_value_t = 4)]
     nb_retry: u32,
 


### PR DESCRIPTION
## Summary
- fix the comment describing `nb_retry`

## Testing
- `cargo test --locked` *(fails: failed to download from crates.io)*