### PR TITLE
Add custom MCUmgr group support and HCDF command

### DIFF
--- a/src/default.rs
+++ b/src/default.rs
@@ -15,7 +15,7 @@ pub fn reset(transport: &mut dyn Transport) -> Result<(), Error> {
     let body = Vec::new();
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Write,
-        NmpGroup::Default,
+        NmpGroup::DEFAULT,
         NmpIdDef::Reset.to_u8(),
         &body,
     )?;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -38,7 +38,7 @@ pub fn download(transport: &mut dyn Transport, remote_path: &str, local_path: &P
 
         let (_response_header, response_body) = transport.transceive(
             NmpOp::Read,
-            NmpGroup::Fs,
+            NmpGroup::FS,
             NmpIdFs::File.to_u8(),
             &body,
         )?;
@@ -129,7 +129,7 @@ pub fn upload(transport: &mut dyn Transport, local_path: &Path, remote_path: &st
 
         let (_response_header, response_body) = transport.transceive(
             NmpOp::Write,
-            NmpGroup::Fs,
+            NmpGroup::FS,
             NmpIdFs::File.to_u8(),
             &body,
         )?;
@@ -167,7 +167,7 @@ pub fn stat(transport: &mut dyn Transport, path: &str) -> Result<FsStatRsp, Erro
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Read,
-        NmpGroup::Fs,
+        NmpGroup::FS,
         NmpIdFs::FileStat.to_u8(),
         &body,
     )?;
@@ -204,7 +204,7 @@ pub fn hash(
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Read,
-        NmpGroup::Fs,
+        NmpGroup::FS,
         NmpIdFs::FileHash.to_u8(),
         &body,
     )?;

--- a/src/image.rs
+++ b/src/image.rs
@@ -22,7 +22,7 @@ pub fn erase(transport: &mut dyn Transport, slot: Option<u32>) -> Result<(), Err
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Write,
-        NmpGroup::Image,
+        NmpGroup::IMAGE,
         NmpIdImage::Erase.to_u8(),
         &body,
     )?;
@@ -45,7 +45,7 @@ pub fn test(
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Write,
-        NmpGroup::Image,
+        NmpGroup::IMAGE,
         NmpIdImage::State.to_u8(),
         &body,
     )?;
@@ -63,7 +63,7 @@ pub fn list(transport: &mut dyn Transport) -> Result<ImageStateRsp, Error> {
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Read,
-        NmpGroup::Image,
+        NmpGroup::IMAGE,
         NmpIdImage::State.to_u8(),
         &body,
     )?;
@@ -148,7 +148,7 @@ where
             sent_blocks += 1;
             match transport.transceive(
                 NmpOp::Write,
-                NmpGroup::Image,
+                NmpGroup::IMAGE,
                 NmpIdImage::Upload.to_u8(),
                 &body,
             ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,10 @@ pub use crate::default::reset;
 pub use crate::fs::{download as fs_download, hash as fs_hash, stat as fs_stat, upload as fs_upload};
 pub use crate::image::{erase, list, test, upload_image};
 pub use crate::nmp_hdr::{
-    BootloaderInfoRsp, FsHashRsp, FsStatRsp, McumgrParamsRsp, SettingsReadRsp, ShellExecRsp,
-    StatListRsp, StatReadRsp, TaskInfo, TaskStatRsp,
+    BootloaderInfoRsp, FsHashRsp, FsStatRsp, McumgrParamsRsp, NmpGroup, NmpOp, SettingsReadRsp,
+    ShellExecRsp, StatListRsp, StatReadRsp, TaskInfo, TaskStatRsp,
 };
+pub use crate::util::empty_cbor_body;
 pub use crate::os::{bootloader_info, echo, mcuboot_mode_name, mcumgr_params, os_info, taskstat};
 pub use crate::settings::{
     settings_commit, settings_delete, settings_load, settings_read, settings_save, settings_write,

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,6 +249,29 @@ enum Commands {
 
     /// save settings to persistent storage
     SettingsSave,
+
+    // ============== Custom Group ==============
+    /// send a raw request to a custom MCUmgr group
+    Custom {
+        /// MCUmgr group ID (e.g., 100 for HCDF)
+        #[arg(short, long)]
+        group: u16,
+
+        /// command ID within the group
+        #[arg(short, long, default_value_t = 0)]
+        id: u8,
+
+        /// operation: "read" or "write"
+        #[arg(short, long, default_value = "read")]
+        op: String,
+
+        /// CBOR request body as hex string (empty map if omitted)
+        #[arg(long)]
+        body: Option<String>,
+    },
+
+    /// query HCDF fragment info from a CogniPilot device (custom group 100)
+    HcdfInfo,
 }
 
 fn main() {
@@ -568,6 +591,59 @@ fn execute_command(command: &Commands, transport: &mut dyn Transport, nb_retry: 
         Commands::SettingsSave => {
             settings_save(transport)?;
             println!("Settings saved successfully");
+            Ok(())
+        }
+
+        // ============== Custom Group ==============
+        Commands::Custom { group, id, op, body } => {
+            let nmp_op = match op.as_str() {
+                "read" => NmpOp::Read,
+                "write" => NmpOp::Write,
+                _ => return Err(anyhow::anyhow!("Invalid op '{}': use 'read' or 'write'", op)),
+            };
+
+            let body_bytes = match body {
+                Some(hex_str) => hex::decode(hex_str)
+                    .map_err(|e| anyhow::anyhow!("Invalid hex body: {}", e))?,
+                None => empty_cbor_body(),
+            };
+
+            let (_response_header, response_body) = transport.transceive(
+                nmp_op,
+                NmpGroup::from(*group),
+                *id,
+                &body_bytes,
+            )?;
+
+            println!("{}", serde_json::to_string_pretty(&response_body)?);
+            Ok(())
+        }
+
+        Commands::HcdfInfo => {
+            let (_response_header, response_body) = transport.transceive(
+                NmpOp::Read,
+                NmpGroup::from(100),
+                0,
+                &empty_cbor_body(),
+            )?;
+
+            // Pretty-print HCDF response fields
+            if let serde_cbor::Value::Map(ref map) = response_body {
+                println!("HCDF Fragment Info:");
+                for (key, val) in map.iter() {
+                    if let serde_cbor::Value::Text(k) = key {
+                        match val {
+                            serde_cbor::Value::Text(v) => println!("  {k}: {v}"),
+                            _ => println!("  {k}: {val:?}"),
+                        }
+                    }
+                }
+                if map.is_empty() {
+                    println!("  (no HCDF info available)");
+                }
+            } else {
+                println!("{}", serde_json::to_string_pretty(&response_body)?);
+            }
             Ok(())
         }
     }

--- a/src/nmp_hdr.rs
+++ b/src/nmp_hdr.rs
@@ -27,20 +27,34 @@ pub enum NmpErr {
     ENoEnt = 5,
 }
 
-#[repr(u16)]
-#[derive(Debug, Clone, Copy, FromPrimitive, PartialEq, Deserialize, Serialize)]
-pub enum NmpGroup {
-    Default = 0,
-    Image = 1,
-    Stat = 2,
-    Config = 3,
-    Log = 4,
-    Crash = 5,
-    Split = 6,
-    Run = 7,
-    Fs = 8,
-    Shell = 9,
-    PerUser = 64,
+/// MCUmgr group ID. Supports both standard and custom (vendor/per-user) groups.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct NmpGroup(pub u16);
+
+impl NmpGroup {
+    pub const DEFAULT: NmpGroup = NmpGroup(0);
+    pub const IMAGE: NmpGroup = NmpGroup(1);
+    pub const STAT: NmpGroup = NmpGroup(2);
+    pub const CONFIG: NmpGroup = NmpGroup(3);
+    pub const LOG: NmpGroup = NmpGroup(4);
+    pub const CRASH: NmpGroup = NmpGroup(5);
+    pub const SPLIT: NmpGroup = NmpGroup(6);
+    pub const RUN: NmpGroup = NmpGroup(7);
+    pub const FS: NmpGroup = NmpGroup(8);
+    pub const SHELL: NmpGroup = NmpGroup(9);
+    pub const PER_USER: NmpGroup = NmpGroup(64);
+}
+
+impl From<u16> for NmpGroup {
+    fn from(val: u16) -> Self {
+        NmpGroup(val)
+    }
+}
+
+impl From<NmpGroup> for u16 {
+    fn from(group: NmpGroup) -> Self {
+        group.0
+    }
 }
 
 pub trait NmpId {
@@ -196,7 +210,7 @@ impl NmpHdr {
         buffer.write_u8(self.op as u8)?;
         buffer.write_u8(self.flags)?;
         buffer.write_u16::<BigEndian>(self.len)?;
-        buffer.write_u16::<BigEndian>(self.group as u16)?;
+        buffer.write_u16::<BigEndian>(self.group.0)?;
         buffer.write_u8(self.seq)?;
         buffer.write_u8(self.id)?;
         Ok(buffer)
@@ -206,7 +220,7 @@ impl NmpHdr {
         let op = num::FromPrimitive::from_u8(cursor.read_u8()?).unwrap();
         let flags = cursor.read_u8()?;
         let len = cursor.read_u16::<BigEndian>()?;
-        let group = num::FromPrimitive::from_u16(cursor.read_u16::<BigEndian>()?).unwrap();
+        let group = NmpGroup(cursor.read_u16::<BigEndian>()?);
         let seq = cursor.read_u8()?;
         let id = cursor.read_u8()?;
         Ok(NmpHdr {

--- a/src/os.rs
+++ b/src/os.rs
@@ -18,7 +18,7 @@ pub fn echo(transport: &mut dyn Transport, message: &str) -> Result<String, Erro
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Write,
-        NmpGroup::Default,
+        NmpGroup::DEFAULT,
         NmpIdDef::Echo.to_u8(),
         &body,
     )?;
@@ -39,7 +39,7 @@ pub fn taskstat(transport: &mut dyn Transport) -> Result<TaskStatRsp, Error> {
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Read,
-        NmpGroup::Default,
+        NmpGroup::DEFAULT,
         NmpIdDef::TaskStat.to_u8(),
         &body,
     )?;
@@ -60,7 +60,7 @@ pub fn mcumgr_params(transport: &mut dyn Transport) -> Result<McumgrParamsRsp, E
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Read,
-        NmpGroup::Default,
+        NmpGroup::DEFAULT,
         NmpIdDef::McumgrParams.to_u8(),
         &body,
     )?;
@@ -96,7 +96,7 @@ pub fn os_info(transport: &mut dyn Transport, format: Option<&str>) -> Result<St
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Read,
-        NmpGroup::Default,
+        NmpGroup::DEFAULT,
         NmpIdDef::Info.to_u8(),
         &body,
     )?;
@@ -126,7 +126,7 @@ pub fn bootloader_info(transport: &mut dyn Transport, query: Option<&str>) -> Re
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Read,
-        NmpGroup::Default,
+        NmpGroup::DEFAULT,
         NmpIdDef::BootloaderInfo.to_u8(),
         &body,
     )?;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -19,7 +19,7 @@ pub fn settings_read(transport: &mut dyn Transport, name: &str, max_size: Option
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Read,
-        NmpGroup::Config,
+        NmpGroup::CONFIG,
         NmpIdConfig::Val.to_u8(),
         &body,
     )?;
@@ -48,7 +48,7 @@ pub fn settings_write(transport: &mut dyn Transport, name: &str, value: Vec<u8>)
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Write,
-        NmpGroup::Config,
+        NmpGroup::CONFIG,
         NmpIdConfig::Val.to_u8(),
         &body,
     )?;
@@ -72,7 +72,7 @@ pub fn settings_delete(transport: &mut dyn Transport, name: &str) -> Result<(), 
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Write,
-        NmpGroup::Config,
+        NmpGroup::CONFIG,
         NmpIdConfig::Val.to_u8(),
         &body,
     )?;
@@ -94,7 +94,7 @@ pub fn settings_commit(transport: &mut dyn Transport) -> Result<(), Error> {
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Write,
-        NmpGroup::Config,
+        NmpGroup::CONFIG,
         NmpIdConfig::Val.to_u8(),
         &body,
     )?;
@@ -116,7 +116,7 @@ pub fn settings_load(transport: &mut dyn Transport) -> Result<(), Error> {
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Read,
-        NmpGroup::Config,
+        NmpGroup::CONFIG,
         NmpIdConfig::Val.to_u8(),
         &body,
     )?;
@@ -138,7 +138,7 @@ pub fn settings_save(transport: &mut dyn Transport) -> Result<(), Error> {
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Write,
-        NmpGroup::Config,
+        NmpGroup::CONFIG,
         NmpIdConfig::Val.to_u8(),
         &body,
     )?;

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -18,7 +18,7 @@ pub fn shell_exec(transport: &mut dyn Transport, argv: Vec<String>) -> Result<Sh
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Write,
-        NmpGroup::Shell,
+        NmpGroup::SHELL,
         NmpIdShell::Exec.to_u8(),
         &body,
     )?;

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -15,7 +15,7 @@ pub fn stat_list(transport: &mut dyn Transport) -> Result<StatListRsp, Error> {
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Read,
-        NmpGroup::Stat,
+        NmpGroup::STAT,
         NmpIdStat::List.to_u8(),
         &body,
     )?;
@@ -43,7 +43,7 @@ pub fn stat_read(transport: &mut dyn Transport, name: &str) -> Result<StatReadRs
 
     let (_response_header, response_body) = transport.transceive(
         NmpOp::Read,
-        NmpGroup::Stat,
+        NmpGroup::STAT,
         NmpIdStat::Read.to_u8(),
         &body,
     )?;

--- a/src/test_serial_port.rs
+++ b/src/test_serial_port.rs
@@ -103,7 +103,7 @@ impl Write for TestSerialPort {
                     let (encoded_response, _) = encode_request(
                         100,
                         NmpOp::ReadRsp,
-                        NmpGroup::Image,
+                        NmpGroup::IMAGE,
                         NmpIdImage::State,
                         &body,
                         request_header.seq,
@@ -116,7 +116,7 @@ impl Write for TestSerialPort {
                     let (encoded_response, _) = encode_request(
                         100,
                         NmpOp::WriteRsp,
-                        NmpGroup::Image,
+                        NmpGroup::IMAGE,
                         NmpIdImage::Erase,
                         &body,
                         request_header.seq,
@@ -148,7 +148,7 @@ impl Write for TestSerialPort {
                 let (encoded_response, _) = encode_request(
                     4096,
                     NmpOp::WriteRsp,
-                    NmpGroup::Image,
+                    NmpGroup::IMAGE,
                     NmpIdImage::Upload,
                     &cbor_body,
                     request_header.seq,
@@ -162,7 +162,7 @@ impl Write for TestSerialPort {
                 let (encoded_response, _) = encode_request(
                     100,
                     NmpOp::WriteRsp,
-                    NmpGroup::Image,
+                    NmpGroup::IMAGE,
                     NmpIdImage::Erase,
                     &body,
                     request_header.seq,

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -231,15 +231,14 @@ impl UdpTransport {
         let version: u8 = 1; // SMP v2
         let byte0 = ((version & 0x03) << 3) | (op as u8 & 0x07);
         let flags: u8 = 0;
-        let group_u16 = group as u16;
 
         [
             byte0,
             flags,
             (len >> 8) as u8,
             (len & 0xFF) as u8,
-            (group_u16 >> 8) as u8,
-            (group_u16 & 0xFF) as u8,
+            (group.0 >> 8) as u8,
+            (group.0 & 0xFF) as u8,
             seq,
             id,
         ]
@@ -268,8 +267,7 @@ impl UdpTransport {
             _ => bail!("Unknown op: {}", op_val),
         };
 
-        let group = num::FromPrimitive::from_u16(group_val)
-            .ok_or_else(|| anyhow::anyhow!("Unknown group: {}", group_val))?;
+        let group = NmpGroup(group_val);
 
         Ok(NmpHdr {
             op,


### PR DESCRIPTION
# Summary
- Replace NmpGroup enum with a NmpGroup(pub u16) newtype struct to support arbitrary MCUmgr group IDs, not just the standard ones hardcoded in the enum
- Add custom CLI command for sending raw requests to any MCUmgr group/command
- Add hcdf-info CLI command as an example use case (CogniPilot custom group 100)
- Export NmpGroup, NmpOp, and empty_cbor_body from the library for downstream use

# Motivation
The MCUmgr protocol supports vendor/per-user groups (IDs 64+), but the previous NmpGroup enum could only represent the standard groups. This meant that custom groups like CogniPilot's HCDF (group 100) couldn't be used through mcumgr-client at all — the UDP transport's decode_header would error on any unknown group ID, and there was no way to pass a custom group through the Transport trait.

By changing NmpGroup from an enum to a newtype wrapper around u16, any group ID works without code changes. The standard groups are still available as associated constants (e.g., NmpGroup::IMAGE). The constant names changed from PascalCase enum variants to SCREAMING_SNAKE_CASE to follow Rust's convention for associated constants on structs.

# New CLI commands

### Send a raw request to any custom MCUmgr group
`mcumgr-client --host 192.168.1.x custom --group 100 --id 0 --op read`

### Optionally pass a hex-encoded CBOR body
`mcumgr-client --host 192.168.1.x custom --group 100 --id 1 --op write --body "a1636b657963766178"`

### Query HCDF fragment info (shorthand for group 100, id 0, read)
`mcumgr-client --host 192.168.1.x hcdf-info`

# Test plan
- [x] cargo build compiles cleanly
- [x] cargo test — all existing tests pass
- [ ] Manual test: custom command against a device with a known custom group
- [x] Manual test: hcdf-info against a CogniPilot device

Closes #40  