### PR TITLE
Fix Cargo.lock file to match Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "mcumgr-client"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "base64",


### PR DESCRIPTION
Running `cargo build --frozen` errors as the version listed in the Cargo.lock file does not match the one listed in the Cargo.toml file.

Updated with `cargo update -p mcumgr-client` to not update any other dependencies