### PR TITLE
feat: add BLE transport layer for MCUmgr over SMP

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,19 +21,23 @@ jobs:
             archive_name: mcumgr-client-windows-x86
             os: ubuntu-latest
             file_extension: .exe
-          - target: x86_64-unknown-linux-musl
+          - target: x86_64-unknown-linux-gnu
             archive_name: mcumgr-client-linux-x86
             os: ubuntu-latest
-          - target: aarch64-unknown-linux-musl
+          - target: aarch64-unknown-linux-gnu
             archive_name: mcumgr-client-linux-aarch64
             os: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Install windows dependencies
         if: matrix.target == 'x86_64-pc-windows-gnu'
         run: sudo apt-get install mingw-w64
+
+      - name: Install linux dependencies
+        if: matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-gnu'
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bincode",
- "bluer",
+ "btleplug",
  "byteorder",
  "clap",
  "crc16",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,9 +368,11 @@ dependencies = [
  "anyhow",
  "base64",
  "bincode",
+ "bluer",
  "byteorder",
  "clap",
  "crc16",
+ "futures",
  "hex",
  "hex-buffer-serde",
  "humantime",
@@ -389,6 +391,8 @@ dependencies = [
  "serialport",
  "sha2",
  "simplelog",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ include = [
 
 [dependencies]
 anyhow = "1.0"
+bluer = { version = "0.17", features = ["bluetoothd"] }
+futures = "0.3"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "time"] }
+uuid = "1"
 base64 = "0.21"
 bincode = "1.3"
 byteorder = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ include = [
 
 [dependencies]
 anyhow = "1.0"
-bluer = { version = "0.17", features = ["bluetoothd"] }
+btleplug = "0.11"
 futures = "0.3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time"] }
 uuid = "1"

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -1,0 +1,298 @@
+use anyhow::{bail, Context, Error, Result};
+use bluer::{AdapterEvent, Address, Session};
+use bluer::gatt::remote::Characteristic;
+use futures::StreamExt;
+use log::debug;
+use std::str::FromStr;
+use tokio::time::{timeout, Duration};
+use uuid::{uuid, Uuid};
+
+use crate::nmp_hdr::{NmpGroup, NmpHdr, NmpOp};
+use crate::transfer::Transport;
+
+const SMP_SERVICE_UUID: Uuid = uuid!("8D53DC1D-1DB7-4CD3-868B-8A527460AA84");
+const SMP_CHAR_UUID: Uuid = uuid!("DA2E7828-FBCE-4E01-AE9E-261174997C48");
+
+#[derive(Debug, Clone)]
+pub struct BleSpecs {
+    pub address: Option<String>,
+    pub name: Option<String>,
+    pub scan_timeout_s: u32,
+    pub timeout_s: u32,
+    pub mtu: usize,
+}
+
+impl Default for BleSpecs {
+    fn default() -> Self {
+        BleSpecs {
+            address: None,
+            name: None,
+            scan_timeout_s: 10,
+            timeout_s: 10,
+            mtu: 244,
+        }
+    }
+}
+
+pub struct BleTransport {
+    rt: tokio::runtime::Runtime,
+    // Keep session alive so the D-Bus connection and BlueZ device handle remain valid
+    _session: Session,
+    characteristic: Characteristic,
+    seq: u8,
+    timeout_ms: u32,
+    mtu: usize,
+}
+
+impl BleTransport {
+    pub fn new(specs: &BleSpecs) -> Result<Self, Error> {
+        if specs.address.is_none() && specs.name.is_none() {
+            bail!("Either --ble-address or --ble-name must be provided");
+        }
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("Failed to build tokio runtime")?;
+
+        let (session, characteristic) = rt.block_on(Self::connect_async(specs))?;
+
+        Ok(BleTransport {
+            rt,
+            _session: session,
+            characteristic,
+            seq: 0,
+            timeout_ms: specs.timeout_s * 1000,
+            mtu: specs.mtu,
+        })
+    }
+
+    async fn connect_async(specs: &BleSpecs) -> Result<(Session, Characteristic), Error> {
+        let session = Session::new().await.context("Failed to create BlueZ session")?;
+        let adapter = session.default_adapter().await.context("No Bluetooth adapter found")?;
+        adapter.set_powered(true).await.context("Failed to power on Bluetooth adapter")?;
+
+        let target_addr: Option<Address> = specs.address.as_deref()
+            .map(|s| Address::from_str(s))
+            .transpose()
+            .context("Invalid BLE address")?;
+        let target_name: Option<String> = specs.name.clone();
+        let scan_timeout = specs.scan_timeout_s;
+
+        debug!("Starting BLE device discovery (timeout: {}s)...", scan_timeout);
+
+        // Clone adapter for use inside the async move block; original is used after scan.
+        let adapter_scan = adapter.clone();
+        let mut discover = adapter.discover_devices().await
+            .context("Failed to start BLE device discovery")?;
+
+        let device_addr = timeout(Duration::from_secs(scan_timeout as u64), async move {
+            while let Some(evt) = discover.next().await {
+                if let AdapterEvent::DeviceAdded(addr) = evt {
+                    // Match by address
+                    if let Some(target) = target_addr {
+                        if addr == target {
+                            debug!("Found target BLE device at {}", addr);
+                            return Some(addr);
+                        }
+                    }
+                    // Match by name
+                    if let Some(ref name) = target_name {
+                        if let Ok(device) = adapter_scan.device(addr) {
+                            if let Ok(Some(n)) = device.name().await {
+                                if n.contains(name.as_str()) {
+                                    debug!("Found BLE device '{}' at {}", n, addr);
+                                    return Some(addr);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            None
+        })
+        .await
+        .ok()
+        .flatten()
+        .ok_or_else(|| anyhow::anyhow!(
+            "BLE device not found within {}s — ensure the device is advertising",
+            scan_timeout
+        ))?;
+
+        let device = adapter.device(device_addr)
+            .with_context(|| format!("Failed to access device {}", device_addr))?;
+
+        if !device.is_connected().await.unwrap_or(false) {
+            debug!("Connecting to {}...", device_addr);
+            device.connect().await
+                .with_context(|| format!("Failed to connect to {}", device_addr))?;
+            debug!("Connected to {}", device_addr);
+        } else {
+            debug!("Already connected to {}", device_addr);
+        }
+
+        // Discover SMP GATT service and characteristic
+        let mut found_char: Option<Characteristic> = None;
+        'outer: for service in device.services().await.context("Failed to discover GATT services")? {
+            if service.uuid().await.unwrap_or_default() == SMP_SERVICE_UUID {
+                for char in service.characteristics().await
+                    .context("Failed to discover GATT characteristics")?
+                {
+                    if char.uuid().await.unwrap_or_default() == SMP_CHAR_UUID {
+                        debug!("Found SMP characteristic");
+                        found_char = Some(char);
+                        break 'outer;
+                    }
+                }
+            }
+        }
+
+        let characteristic = found_char.ok_or_else(|| anyhow::anyhow!(
+            "SMP characteristic not found — ensure the device has BLE SMP service enabled"
+        ))?;
+
+        Ok((session, characteristic))
+    }
+
+    fn next_seq(&mut self) -> u8 {
+        let seq = self.seq;
+        self.seq = self.seq.wrapping_add(1);
+        seq
+    }
+
+    fn encode_smp_header(op: NmpOp, group: NmpGroup, id: u8, len: u16, seq: u8) -> [u8; 8] {
+        let version: u8 = 1; // SMP v2
+        let byte0 = ((version & 0x03) << 3) | (op as u8 & 0x07);
+        [
+            byte0, 0,
+            (len >> 8) as u8, (len & 0xFF) as u8,
+            (group.0 >> 8) as u8, (group.0 & 0xFF) as u8,
+            seq, id,
+        ]
+    }
+
+    fn decode_smp_header(data: &[u8]) -> Result<NmpHdr, Error> {
+        if data.len() < 8 {
+            bail!("BLE response too short: {} bytes", data.len());
+        }
+        let op_val = data[0] & 0x07;
+        let len = ((data[2] as u16) << 8) | (data[3] as u16);
+        let group_val = ((data[4] as u16) << 8) | (data[5] as u16);
+        let seq = data[6];
+        let id = data[7];
+        let op = match op_val {
+            0 => NmpOp::Read,
+            1 => NmpOp::ReadRsp,
+            2 => NmpOp::Write,
+            3 => NmpOp::WriteRsp,
+            _ => bail!("Unknown SMP op: {}", op_val),
+        };
+        Ok(NmpHdr { op, flags: 0, len, group: NmpGroup(group_val), seq, id })
+    }
+}
+
+impl Transport for BleTransport {
+    fn transceive(
+        &mut self,
+        op: NmpOp,
+        group: NmpGroup,
+        id: u8,
+        body: &[u8],
+    ) -> Result<(NmpHdr, serde_cbor::Value), Error> {
+        let seq = self.next_seq();
+        let header = Self::encode_smp_header(op, group, id, body.len() as u16, seq);
+        let mut packet = Vec::with_capacity(8 + body.len());
+        packet.extend_from_slice(&header);
+        packet.extend_from_slice(body);
+
+        debug!("BLE TX: {} bytes", packet.len());
+
+        let char = self.characteristic.clone();
+        let timeout_ms = self.timeout_ms;
+
+        // Subscribe to notifications, send request, then collect response fragments.
+        // BLE ATT notifications may carry partial SMP payloads if the packet exceeds ATT MTU.
+        let response = self.rt.block_on(async move {
+            let notify_stream = char.notify().await
+                .context("Failed to subscribe to SMP notifications")?;
+            tokio::pin!(notify_stream);
+
+            char.write(&packet).await
+                .context("Failed to write to SMP characteristic")?;
+
+            // Collect the first notification to read the SMP header + partial payload
+            let first = timeout(
+                Duration::from_millis(timeout_ms as u64),
+                notify_stream.next(),
+            )
+            .await
+            .map_err(|_| anyhow::anyhow!("BLE response timeout after {}ms", timeout_ms))?
+            .ok_or_else(|| anyhow::anyhow!("BLE notification stream closed"))?;
+
+            if first.len() < 8 {
+                bail!("BLE first notification too short: {} bytes", first.len());
+            }
+
+            let total_payload = ((first[2] as usize) << 8) | (first[3] as usize);
+            let mut payload = first[8..].to_vec();
+
+            // Accumulate additional notifications if the SMP payload is fragmented
+            while payload.len() < total_payload {
+                let fragment = timeout(
+                    Duration::from_millis(timeout_ms as u64),
+                    notify_stream.next(),
+                )
+                .await
+                .map_err(|_| anyhow::anyhow!("BLE fragment timeout after {}ms", timeout_ms))?
+                .ok_or_else(|| anyhow::anyhow!("BLE notification stream closed mid-packet"))?;
+
+                payload.extend_from_slice(&fragment);
+            }
+
+            // Return header bytes + reassembled payload as a flat buffer
+            let mut full = first[..8].to_vec();
+            full.extend_from_slice(&payload[..total_payload]);
+            Ok::<Vec<u8>, Error>(full)
+        })?;
+
+        debug!("BLE RX: {} bytes", response.len());
+
+        let response_header = Self::decode_smp_header(&response)?;
+
+        if response_header.seq != seq {
+            bail!("Sequence mismatch: expected {}, got {}", seq, response_header.seq);
+        }
+
+        let expected_op = match op {
+            NmpOp::Read => NmpOp::ReadRsp,
+            NmpOp::Write => NmpOp::WriteRsp,
+            _ => bail!("Unexpected request op type"),
+        };
+
+        if response_header.op != expected_op || response_header.group != group {
+            bail!("Wrong response type");
+        }
+
+        let cbor_data = &response[8..];
+        let body: serde_cbor::Value = if cbor_data.is_empty() {
+            serde_cbor::Value::Map(std::collections::BTreeMap::new())
+        } else {
+            serde_cbor::from_slice(cbor_data).context("Failed to parse CBOR response")?
+        };
+
+        Ok((response_header, body))
+    }
+
+    fn set_timeout(&mut self, timeout_ms: u32) -> Result<(), Error> {
+        self.timeout_ms = timeout_ms;
+        Ok(())
+    }
+
+    fn mtu(&self) -> usize {
+        self.mtu
+    }
+
+    fn linelength(&self) -> usize {
+        self.mtu
+    }
+}

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -1,9 +1,12 @@
 use anyhow::{bail, Context, Error, Result};
-use bluer::{AdapterEvent, Address, Session};
-use bluer::gatt::remote::Characteristic;
+use btleplug::api::{
+    Central, CentralEvent, Characteristic, Manager as _, Peripheral as _, ScanFilter,
+    ValueNotification, WriteType,
+};
+use btleplug::platform::{Manager, Peripheral};
 use futures::StreamExt;
 use log::debug;
-use std::str::FromStr;
+use std::pin::Pin;
 use tokio::time::{timeout, Duration};
 use uuid::{uuid, Uuid};
 
@@ -34,14 +37,29 @@ impl Default for BleSpecs {
     }
 }
 
+// Groups async state so that transceive() can borrow it separately from the runtime.
+struct BleConnection {
+    peripheral: Peripheral,
+    smp_char: Characteristic,
+    notifications: Pin<Box<dyn futures::Stream<Item = ValueNotification> + Send>>,
+}
+
 pub struct BleTransport {
     rt: tokio::runtime::Runtime,
-    // Keep session alive so the D-Bus connection and BlueZ device handle remain valid
-    _session: Session,
-    characteristic: Characteristic,
+    // Wrapped in Option so Drop can take it and destroy it inside block_on,
+    // which is required because MessageStream::drop calls Handle::current().
+    conn: Option<BleConnection>,
     seq: u8,
     timeout_ms: u32,
     mtu: usize,
+}
+
+impl Drop for BleTransport {
+    fn drop(&mut self) {
+        if let Some(conn) = self.conn.take() {
+            self.rt.block_on(async move { drop(conn) });
+        }
+    }
 }
 
 impl BleTransport {
@@ -50,108 +68,140 @@ impl BleTransport {
             bail!("Either --ble-address or --ble-name must be provided");
         }
 
-        let rt = tokio::runtime::Builder::new_current_thread()
+        let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .context("Failed to build tokio runtime")?;
 
-        let (session, characteristic) = rt.block_on(Self::connect_async(specs))?;
+        let conn = rt.block_on(Self::connect_async(specs))?;
 
         Ok(BleTransport {
             rt,
-            _session: session,
-            characteristic,
+            conn: Some(conn),
             seq: 0,
             timeout_ms: specs.timeout_s * 1000,
             mtu: specs.mtu,
         })
     }
 
-    async fn connect_async(specs: &BleSpecs) -> Result<(Session, Characteristic), Error> {
-        let session = Session::new().await.context("Failed to create BlueZ session")?;
-        let adapter = session.default_adapter().await.context("No Bluetooth adapter found")?;
-        adapter.set_powered(true).await.context("Failed to power on Bluetooth adapter")?;
+    async fn connect_async(specs: &BleSpecs) -> Result<BleConnection, Error> {
+        let manager = Manager::new().await.context("Failed to initialize BLE manager")?;
+        let adapters = manager.adapters().await.context("Failed to list BLE adapters")?;
+        let adapter = adapters
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("No Bluetooth adapter found"))?;
 
-        let target_addr: Option<Address> = specs.address.as_deref()
-            .map(|s| Address::from_str(s))
-            .transpose()
-            .context("Invalid BLE address")?;
-        let target_name: Option<String> = specs.name.clone();
+        let target_addr = specs.address.clone();
+        let target_name = specs.name.clone();
         let scan_timeout = specs.scan_timeout_s;
 
         debug!("Starting BLE device discovery (timeout: {}s)...", scan_timeout);
 
-        // Clone adapter for use inside the async move block; original is used after scan.
-        let adapter_scan = adapter.clone();
-        let mut discover = adapter.discover_devices().await
-            .context("Failed to start BLE device discovery")?;
+        adapter
+            .start_scan(ScanFilter::default())
+            .await
+            .context("Failed to start BLE scan")?;
 
-        let device_addr = timeout(Duration::from_secs(scan_timeout as u64), async move {
-            while let Some(evt) = discover.next().await {
-                if let AdapterEvent::DeviceAdded(addr) = evt {
-                    // Match by address
-                    if let Some(target) = target_addr {
-                        if addr == target {
-                            debug!("Found target BLE device at {}", addr);
-                            return Some(addr);
+        let mut events = adapter
+            .events()
+            .await
+            .context("Failed to subscribe to adapter events")?;
+
+        let peripheral = timeout(
+            Duration::from_secs(scan_timeout as u64),
+            async {
+                while let Some(event) = events.next().await {
+                    // DeviceUpdated fires when advertisement data (e.g. name) arrives after discovery
+                    let id = match event {
+                        CentralEvent::DeviceDiscovered(id) | CentralEvent::DeviceUpdated(id) => id,
+                        _ => continue,
+                    };
+
+                    let Ok(p) = adapter.peripheral(&id).await else {
+                        continue;
+                    };
+
+                    // MAC address matching — not available on macOS (CoreBluetooth hides MACs)
+                    #[cfg(not(target_os = "macos"))]
+                    if let Some(ref addr) = target_addr {
+                        if p.address().to_string().eq_ignore_ascii_case(addr) {
+                            debug!("Found target BLE device at {}", p.address());
+                            return Some(p);
                         }
                     }
-                    // Match by name
+
                     if let Some(ref name) = target_name {
-                        if let Ok(device) = adapter_scan.device(addr) {
-                            if let Ok(Some(n)) = device.name().await {
+                        if let Ok(Some(props)) = p.properties().await {
+                            if let Some(ref n) = props.local_name {
                                 if n.contains(name.as_str()) {
-                                    debug!("Found BLE device '{}' at {}", n, addr);
-                                    return Some(addr);
+                                    debug!("Found BLE device '{}' at {}", n, p.address());
+                                    return Some(p);
                                 }
                             }
                         }
                     }
                 }
-            }
-            None
-        })
+                None
+            },
+        )
         .await
         .ok()
         .flatten()
-        .ok_or_else(|| anyhow::anyhow!(
-            "BLE device not found within {}s — ensure the device is advertising",
-            scan_timeout
-        ))?;
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "BLE device not found within {}s — ensure the device is advertising",
+                scan_timeout
+            )
+        })?;
 
-        let device = adapter.device(device_addr)
-            .with_context(|| format!("Failed to access device {}", device_addr))?;
+        adapter.stop_scan().await.ok();
 
-        if !device.is_connected().await.unwrap_or(false) {
-            debug!("Connecting to {}...", device_addr);
-            device.connect().await
-                .with_context(|| format!("Failed to connect to {}", device_addr))?;
-            debug!("Connected to {}", device_addr);
+        if !peripheral.is_connected().await.unwrap_or(false) {
+            debug!("Connecting to {}...", peripheral.address());
+            peripheral
+                .connect()
+                .await
+                .with_context(|| format!("Failed to connect to {}", peripheral.address()))?;
+            debug!("Connected to {}", peripheral.address());
         } else {
-            debug!("Already connected to {}", device_addr);
+            debug!("Already connected to {}", peripheral.address());
         }
 
-        // Discover SMP GATT service and characteristic
-        let mut found_char: Option<Characteristic> = None;
-        'outer: for service in device.services().await.context("Failed to discover GATT services")? {
-            if service.uuid().await.unwrap_or_default() == SMP_SERVICE_UUID {
-                for char in service.characteristics().await
-                    .context("Failed to discover GATT characteristics")?
-                {
-                    if char.uuid().await.unwrap_or_default() == SMP_CHAR_UUID {
-                        debug!("Found SMP characteristic");
-                        found_char = Some(char);
-                        break 'outer;
-                    }
-                }
-            }
-        }
+        peripheral
+            .discover_services()
+            .await
+            .context("Failed to discover GATT services")?;
 
-        let characteristic = found_char.ok_or_else(|| anyhow::anyhow!(
-            "SMP characteristic not found — ensure the device has BLE SMP service enabled"
-        ))?;
+        let smp_char = peripheral
+            .services()
+            .into_iter()
+            .find(|s| s.uuid == SMP_SERVICE_UUID)
+            .and_then(|s| s.characteristics.into_iter().find(|c| c.uuid == SMP_CHAR_UUID))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "SMP characteristic not found — ensure the device has BLE SMP service enabled"
+                )
+            })?;
 
-        Ok((session, characteristic))
+        debug!("Found SMP characteristic");
+
+        // Subscribe once; the resulting stream is reused across all transceive() calls.
+        peripheral
+            .subscribe(&smp_char)
+            .await
+            .context("Failed to subscribe to SMP characteristic notifications")?;
+
+        let notifications = peripheral
+            .notifications()
+            .await
+            .context("Failed to open BLE notification stream")?;
+
+        Ok(BleConnection {
+            peripheral,
+            smp_char,
+            notifications,
+        })
     }
 
     fn next_seq(&mut self) -> u8 {
@@ -164,10 +214,14 @@ impl BleTransport {
         let version: u8 = 1; // SMP v2
         let byte0 = ((version & 0x03) << 3) | (op as u8 & 0x07);
         [
-            byte0, 0,
-            (len >> 8) as u8, (len & 0xFF) as u8,
-            (group.0 >> 8) as u8, (group.0 & 0xFF) as u8,
-            seq, id,
+            byte0,
+            0,
+            (len >> 8) as u8,
+            (len & 0xFF) as u8,
+            (group.0 >> 8) as u8,
+            (group.0 & 0xFF) as u8,
+            seq,
+            id,
         ]
     }
 
@@ -187,7 +241,14 @@ impl BleTransport {
             3 => NmpOp::WriteRsp,
             _ => bail!("Unknown SMP op: {}", op_val),
         };
-        Ok(NmpHdr { op, flags: 0, len, group: NmpGroup(group_val), seq, id })
+        Ok(NmpHdr {
+            op,
+            flags: 0,
+            len,
+            group: NmpGroup(group_val),
+            seq,
+            id,
+        })
     }
 }
 
@@ -207,23 +268,31 @@ impl Transport for BleTransport {
 
         debug!("BLE TX: {} bytes", packet.len());
 
-        let char = self.characteristic.clone();
         let timeout_ms = self.timeout_ms;
+        // Borrow rt and conn as disjoint fields so the async block can capture conn.
+        let rt = &self.rt;
+        let conn = self.conn.as_mut().unwrap();
 
-        // Subscribe to notifications, send request, then collect response fragments.
-        // BLE ATT notifications may carry partial SMP payloads if the packet exceeds ATT MTU.
-        let response = self.rt.block_on(async move {
-            let notify_stream = char.notify().await
-                .context("Failed to subscribe to SMP notifications")?;
-            tokio::pin!(notify_stream);
-
-            char.write(&packet).await
+        let response = rt.block_on(async {
+            conn.peripheral
+                .write(&conn.smp_char, &packet, WriteType::WithoutResponse)
+                .await
                 .context("Failed to write to SMP characteristic")?;
 
-            // Collect the first notification to read the SMP header + partial payload
+            // Collect the first notification that carries an SMP response.
+            // The stream may deliver notifications for other characteristics if any were
+            // subscribed by the platform; filter by UUID to be safe.
             let first = timeout(
                 Duration::from_millis(timeout_ms as u64),
-                notify_stream.next(),
+                async {
+                    loop {
+                        match conn.notifications.next().await {
+                            Some(n) if n.uuid == SMP_CHAR_UUID => break Some(n.value),
+                            Some(_) => continue,
+                            None => break None,
+                        }
+                    }
+                },
             )
             .await
             .map_err(|_| anyhow::anyhow!("BLE response timeout after {}ms", timeout_ms))?
@@ -236,11 +305,19 @@ impl Transport for BleTransport {
             let total_payload = ((first[2] as usize) << 8) | (first[3] as usize);
             let mut payload = first[8..].to_vec();
 
-            // Accumulate additional notifications if the SMP payload is fragmented
+            // Accumulate additional notifications if the SMP payload is fragmented across ATT MTU
             while payload.len() < total_payload {
                 let fragment = timeout(
                     Duration::from_millis(timeout_ms as u64),
-                    notify_stream.next(),
+                    async {
+                        loop {
+                            match conn.notifications.next().await {
+                                Some(n) if n.uuid == SMP_CHAR_UUID => break Some(n.value),
+                                Some(_) => continue,
+                                None => break None,
+                            }
+                        }
+                    },
                 )
                 .await
                 .map_err(|_| anyhow::anyhow!("BLE fragment timeout after {}ms", timeout_ms))?
@@ -249,7 +326,6 @@ impl Transport for BleTransport {
                 payload.extend_from_slice(&fragment);
             }
 
-            // Return header bytes + reassembled payload as a flat buffer
             let mut full = first[..8].to_vec();
             full.extend_from_slice(&payload[..total_payload]);
             Ok::<Vec<u8>, Error>(full)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod ble;
 mod default;
 mod fs;
 mod image;
@@ -24,4 +25,5 @@ pub use crate::settings::{
 };
 pub use crate::shell::shell_exec;
 pub use crate::stat::{stat_list, stat_read};
+pub use crate::ble::{BleSpecs, BleTransport};
 pub use crate::transfer::{ConnSpec, SerialSpecs, SerialTransport, Transport, UdpSpecs, UdpTransport};

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,22 @@ struct Cli {
     #[arg(short, long, default_value_t = 115_200)]
     baudrate: u32,
 
+    /// BLE device address (e.g. AA:BB:CC:DD:EE:FF)
+    #[arg(long)]
+    ble_address: Option<String>,
+
+    /// BLE device name to scan for
+    #[arg(long)]
+    ble_name: Option<String>,
+
+    /// BLE scan/connect timeout in seconds
+    #[arg(long, default_value_t = 10)]
+    ble_timeout: u32,
+
+    /// BLE ATT MTU payload size in bytes
+    #[arg(long, default_value_t = 244)]
+    ble_mtu: usize,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -86,6 +102,20 @@ impl From<&Cli> for SerialSpecs {
 }
 
 impl Cli {
+    fn is_ble(&self) -> bool {
+        self.ble_address.is_some() || self.ble_name.is_some()
+    }
+
+    fn ble_specs(&self) -> BleSpecs {
+        BleSpecs {
+            address: self.ble_address.clone(),
+            name: self.ble_name.clone(),
+            scan_timeout_s: self.ble_timeout,
+            timeout_s: self.initial_timeout_s,
+            mtu: self.ble_mtu,
+        }
+    }
+
     fn is_udp(&self) -> bool {
         self.host.is_some()
     }
@@ -299,7 +329,15 @@ fn main() {
     .unwrap_or_else(|_| SimpleLogger::init(LevelFilter::Info, Default::default()).unwrap());
 
     // Build transport connection
-    let conn = if cli.is_udp() {
+    let conn = if cli.is_ble() {
+        let ble_specs = cli.ble_specs();
+        if let Some(ref addr) = ble_specs.address {
+            info!("Using BLE transport: address {}", addr);
+        } else if let Some(ref name) = ble_specs.name {
+            info!("Using BLE transport: scanning for '{}'", name);
+        }
+        ConnSpec::Ble(ble_specs)
+    } else if cli.is_udp() {
         let udp_specs = cli.udp_specs();
         info!("Using UDP transport: {}:{}", udp_specs.host, udp_specs.port);
         ConnSpec::Udp(udp_specs)

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -14,6 +14,7 @@ use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
+use crate::ble::{BleSpecs, BleTransport};
 use crate::nmp_hdr::*;
 use crate::test_serial_port::TestSerialPort;
 
@@ -38,11 +39,12 @@ pub trait Transport {
     fn linelength(&self) -> usize;
 }
 
-/// Connection specification - either serial or UDP
+/// Connection specification - serial, UDP, or BLE
 #[derive(Debug, Clone)]
 pub enum ConnSpec {
     Serial(SerialSpecs),
     Udp(UdpSpecs),
+    Ble(BleSpecs),
 }
 
 impl ConnSpec {
@@ -55,6 +57,10 @@ impl ConnSpec {
             }
             ConnSpec::Udp(specs) => {
                 let transport = UdpTransport::new(specs)?;
+                Ok(Box::new(transport))
+            }
+            ConnSpec::Ble(specs) => {
+                let transport = BleTransport::new(specs)?;
                 Ok(Box::new(transport))
             }
         }


### PR DESCRIPTION
## Summary

Implements BLE as a transport layer for MCUmgr commands to be sent to Zephyr/MCUboot devices over the standard SMP-over-BLE GATT service (UUID 8D53DC1D / DA2E7828)

## Changes

- Adds `src/ble.rs` responsible for the BLE transport layer using `btleplug`
- Supports device discovery using MAC address (`--ble-address`) or by advertisement name (`--ble-name`)
- Handles SMP packet fragmentation across ATT notifications.
- Extends enum in `transfer.rs` with `Ble(BleSpecs)` variant.
- Adds the following arguments `--ble-address`, `--ble-name`, `--ble-timeout` and `--ble-mtu`. BLE takes precedence
over UDP and serial in transport selection.

**Note**: this is only supported for BlueZ D-Bus (Linux), Windows and MacOS it is not supported yet.

## Usage

```
./mcumgr-client --ble-name <advertising_name> <command>
```

On my local instance I have a device called `vytal 75F1E9`:

```
~ ./mcumgr-client --ble-name "vytal 75F1E9" list
**mcumgr-client 0.0.9

22:15:50 [INFO] Using BLE transport: scanning for 'Vytal 75F1E9'
22:15:50 [INFO] send image list request
response: {
  "images": [
    {
      "image": 0,
      "slot": 0,
      "version": "0.0.1",
      "hash": "13c0525197dedde0d68dcae7485150e18d956ab5673e56ea0ea6e24da5d901c11433ea9420b1106e197c37e623255b58d2faa11feef03179a551a919034526b1",
      "bootable": true,
      "pending": false,
      "confirmed": false,
      "active": true,
      "permanent": false
    },
    {
      "image": 0,
      "slot": 1,
      "version": "0.0.2",
      "hash": "cc834480bf4b0ea50813612baacf4e1c93cccab883d8e4515c09ccc5a03e001bff2d34809cf9eb6be83fcbd19858fdeda985266926a58734800d669ef85e0051",
      "bootable": true,
      "pending": false,
      "confirmed": true,
      "active": false,
      "permanent": false
    }
  ],
  "splitStatus": "NotApplicable**
```