### PR TITLE
bugfix: mtu needs to be calculated on encoded length, not raw data

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -104,7 +104,7 @@ where
     let data = read(filename)?;
     info!("{} bytes to transfer", data.len());
 
-    let mtu = transport.mtu();
+    let max_payload = transport.max_payload();
 
     // transfer in blocks
     let mut off: usize = 0;
@@ -118,32 +118,45 @@ where
 
         loop {
             // create image upload request
-            let chunk_len = mtu.min(data.len() - off);
-            let chunk = data[off..off + chunk_len].to_vec();
-            let len = data.len() as u32;
-            let req = if off == 0 {
-                ImageUploadReq {
-                    image_num: slot,
-                    off: off as u32,
-                    len: Some(len),
-                    data_sha: Some(Sha256::digest(&data).to_vec()),
-                    upgrade: None,
-                    data: chunk,
-                }
-            } else {
-                ImageUploadReq {
-                    image_num: slot,
-                    off: off as u32,
-                    len: None,
-                    data_sha: None,
-                    upgrade: None,
-                    data: chunk,
-                }
-            };
-            debug!("req: {:?}", req);
+            let mut try_length = max_payload.min(data.len() - off);
+            let mut body: Vec<u8>;
 
-            // convert to bytes with CBOR
-            let body = serde_cbor::to_vec(&req)?;
+            loop {
+                if off + try_length > data.len() {
+                    try_length = data.len() - off;
+                }
+
+                let chunk = data[off..off + try_length].to_vec();
+                let len = data.len() as u32;
+                let req = if off == 0 {
+                    ImageUploadReq {
+                        image_num: slot,
+                        off: off as u32,
+                        len: Some(len),
+                        data_sha: Some(Sha256::digest(&data).to_vec()),
+                        upgrade: None,
+                        data: chunk,
+                    }
+                } else {
+                    ImageUploadReq {
+                        image_num: slot,
+                        off: off as u32,
+                        len: None,
+                        data_sha: None,
+                        upgrade: None,
+                        data: chunk,
+                    }
+                };
+                debug!("req: {:?}", req);
+
+                // convert to bytes with CBOR
+                body = serde_cbor::to_vec(&req)?;
+                if body.len() <= max_payload {
+                    break;
+                } else {
+                    try_length -= body.len() - max_payload;
+                }
+            }
 
             sent_blocks += 1;
             match transport.transceive(

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -6,6 +6,8 @@ use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
 use crc16::*;
 use lazy_static::lazy_static;
 use log::debug;
+use num::integer::div_floor;
+use num::ToPrimitive;
 use rand::{thread_rng, Rng};
 use serialport::SerialPort;
 use std::cmp::min;
@@ -33,6 +35,8 @@ pub trait Transport {
 
     /// Get the MTU for this transport
     fn mtu(&self) -> usize;
+
+    fn max_payload(&self) -> usize;
 
     /// Get the line length for this transport (for serial framing)
     fn linelength(&self) -> usize;
@@ -171,6 +175,22 @@ impl Transport for SerialTransport {
 
     fn mtu(&self) -> usize {
         self.specs.mtu
+    }
+
+    fn max_payload(&self) -> usize {
+        // Max overhead of BASE64 encoding + framing bytes, len and CRC
+        let smp_frame_len = div_floor(self.mtu() - 7, 4) * 3;
+
+        // Create a temporary NmpId wrapper
+        struct TempId(u8);
+        impl NmpId for TempId {
+            fn to_u8(&self) -> u8 {
+                self.0
+            }
+        }
+        let hdr = NmpHdr::new_req(NmpOp::Read, NmpGroup(0), TempId(0));
+        let hdr_size = bincode::serialized_size(&hdr).unwrap();
+        return smp_frame_len - hdr_size.to_usize().unwrap();
     }
 
     fn linelength(&self) -> usize {
@@ -364,6 +384,22 @@ impl Transport for UdpTransport {
 
     fn mtu(&self) -> usize {
         self.mtu
+    }
+
+    fn max_payload(&self) -> usize {
+        // Max overhead of BASE64 encoding + framing bytes, len and CRC
+        let smp_frame_len = div_floor(self.mtu() - 7, 4) * 3;
+
+        // Create a temporary NmpId wrapper
+        struct TempId(u8);
+        impl NmpId for TempId {
+            fn to_u8(&self) -> u8 {
+                self.0
+            }
+        }
+        let hdr = NmpHdr::new_req(NmpOp::Read, NmpGroup(0), TempId(0));
+        let hdr_size = bincode::serialized_size(&hdr).unwrap();
+        return smp_frame_len - hdr_size.to_usize().unwrap();
     }
 
     fn linelength(&self) -> usize {


### PR DESCRIPTION
This PR fixes #49 .

Since 0.09 upload has broken if the MTU of your device matches the MTU set in MCUMgr.

The new code uses the MTU as the size of the data fragment before it is cbor encoded, then encoded for the transport.
This is not correct behaviour, as the MTU applies to the final frame.

This PR adds a `max_payload` method to the transport which corresponds to the max number of bytes that can be encoded in the transport frame. For the two existing transports this is easy to calculate (zephyr docs show the number of bytes needed for framing and the base64 overhead is known).

The old code (< 0.08) handled this by encoding, seeing if the final frame was bigger, and decrementing by some amount. This PR can handle avoids this step, but we still need to try CBOR encoding the upload and adjust the chunk size to fit the payload.